### PR TITLE
fix: Corrige o retorno do método Post no SubTaskController

### DIFF
--- a/src/Api/Controllers/SubTaskController.cs
+++ b/src/Api/Controllers/SubTaskController.cs
@@ -29,8 +29,8 @@ public class SubTaskController : Controller
     [HttpPost]
     public IActionResult Post([FromBody] SubTaskRequest newSubTask)
     {
-        _subTaskService.Create(newSubTask);
-        return Ok(newSubTask);
+        var createdSubTask = _subTaskService.Create(newSubTask);
+        return Ok(createdSubTask);
     }
 
     [HttpPut("{subTaskId}")]

--- a/src/TestsBackup/UsuarioTests/SubTaskTests.cs
+++ b/src/TestsBackup/UsuarioTests/SubTaskTests.cs
@@ -1,10 +1,8 @@
+using Api.Controllers;
+using Domain.Models;
+using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
-using Microsoft.EntityFrameworkCore;
-using Api.Controllers;
-using FluentAssertions;
-using Infra.DB;
-using Domain.Models;
 using Service;
 
 namespace Tests
@@ -26,10 +24,6 @@ namespace Tests
             new SubTask { Id = 1, MainTaskId = 4, Description = "Subtask4", Finished = true }
 
         };
-
-
-
-
             _mockContext.Setup(m => m.List(1)).Returns(subtask);
 
             _controller = new SubTaskController(_mockContext.Object);
@@ -57,9 +51,9 @@ namespace Tests
 
 
             var result = _controller.Post(subTaskTest);
-            var item = (result as OkObjectResult)?.Value as SubTaskRequest;
+            var item = (result as OkObjectResult)?.Value as SubTask;
 
-            item.Should().BeEquivalentTo(new SubTaskRequest { MainTaskId = 1, Description = "Very Cool Subtask" });
+            item.Should().BeEquivalentTo(new SubTask { Id = 1, MainTaskId = 1, Description = "Very Cool Subtask", Finished = false });
         }
         [Fact]
         public void Put_UpdatesSubtask_Success()
@@ -69,14 +63,14 @@ namespace Tests
             var newSubTaskUpdate = new SubTaskUpdate() { Description = "New subtask", Finished = true };
 
             _mockContext.Setup(m => m.Update(newSubTaskUpdate, 1)).Returns(newSubTask);
-            
+
 
             //act
             var result = _controller.Put(1, newSubTaskUpdate);
             var item = (result as OkObjectResult)?.Value as SubTask;
 
             //assert
-            item.Should().BeEquivalentTo(new SubTask { MainTaskId = 1, Id = 1, Description = "New subtask", Finished = true});
+            item.Should().BeEquivalentTo(new SubTask { MainTaskId = 1, Id = 1, Description = "New subtask", Finished = true });
 
         }
 


### PR DESCRIPTION
Corrige o retorno do método Post no SubTaskController para garantir que ele retorne o ID da sub-tarefa criada.

Exemplo do novo retorno esperado:
{
	"id": 159,
	"mainTaskId": 72,
	"description": "Exemplo Nova Subtask",
	"finished": false
}